### PR TITLE
Removed '?download=1' from download link

### DIFF
--- a/run
+++ b/run
@@ -24,7 +24,7 @@ cd "$PROJDIR"
 
 [[ -s $tarball ]] || {
     echo "===== Downloading image"
-    curl -L -O "https://zenodo.org/records/7503088/files/$tarball?download=1"
+    curl -L -O "https://zenodo.org/records/7503088/files/$tarball"
 }
 
 [[ $DR = *sudo* ]] && sudo -v -p '[sudo] password for %p (to run docker): '


### PR DESCRIPTION
### Issue

Having the '?download=1' additional string will cause the downloaded file to be named "paper-23.tar.gz?download=1" (at least for my case).

### Change/s in PR

Removed the '?download=1' string. => This works for me.